### PR TITLE
Fix Travis and Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ install:
 
 before_script:
   - docker-compose up -d
+  - docker-compose exec -T web ./script/wait-for-it/wait-for-it.sh postgres:5432
+  - docker-compose exec -T web ./script/wait-for-it/wait-for-it.sh redis:6379
   - docker-compose exec -T -e RACK_ENV=test web bundle exec rake db:create
 script:
   - docker-compose exec -T -e RACK_ENV=test web bundle exec rake db:migrate

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,20 @@
-version:
+version: ~> 1.0
 os: linux
 dist: bionic
 virt: lxd
 language: ruby
+rvm:
+  - 2.4.1
 services:
   - docker
 env:
   - COMPOSE_FILE=./docker-compose.yml
 
-before_install:
+install:
   - docker-compose build --pull
-  - docker-compose up -d
 
 before_script:
+  - docker-compose up -d
   - docker-compose exec -T web RACK_ENV=test bundle exec rake db:create
 script:
   - docker-compose exec -T web RACK_ENV=test bundle exec rake db:migrate

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,23 @@
-sudo: required
+version:
+os: linux
+dist: bionic
+virt: lxd
 language: ruby
 services:
   - docker
-rvm:
-  - 2.4.1
+env:
+  - COMPOSE_FILE=./docker-compose.yml
 
 before_install:
-  - docker build -t instructure/lti_originality_report_example .
+  - docker-compose build --pull
+  - docker-compose up -d
 
 before_script:
-  - RACK_ENV=test bundle exec rake db:create
+  - docker-compose exec -T web RACK_ENV=test bundle exec rake db:create
 script:
-  - RACK_ENV=test bundle exec rake db:migrate
-  - bundle exec rake rubocop
-  - bundle exec rake
+  - docker-compose exec -T web RACK_ENV=test bundle exec rake db:migrate
+  - docker-compose exec -T web bundle exec rake rubocop
+  - docker-compose exec -T bundle exec rake
+after_script:
+  # Cleanup docker-compose stuff.
+  - docker-compose down --remove-orphans --rmi all

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ rvm:
 services:
   - docker
 env:
-  - COMPOSE_FILE=./docker-compose.yml
+  - COMPOSE_FILE=./docker-compose.yml:docker-compose.test.yml
 
 install:
-  - docker-compose build --pull -q
+  - docker-compose build --pull
 
 before_script:
   - docker-compose up -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,15 @@ env:
   - COMPOSE_FILE=./docker-compose.yml
 
 install:
-  - docker-compose build --pull
+  - docker-compose build --pull -q
 
 before_script:
   - docker-compose up -d
-  - docker-compose exec -T web RACK_ENV=test bundle exec rake db:create
+  - docker-compose exec -T -e RACK_ENV=test web bundle exec rake db:create
 script:
-  - docker-compose exec -T web RACK_ENV=test bundle exec rake db:migrate
+  - docker-compose exec -T -e RACK_ENV=test web bundle exec rake db:migrate
   - docker-compose exec -T web bundle exec rake rubocop
-  - docker-compose exec -T bundle exec rake
+  - docker-compose exec -T web bundle exec rake
 after_script:
   # Cleanup docker-compose stuff.
   - docker-compose down --remove-orphans --rmi all

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,4 @@
+version: "3"
+services:
+  web:
+    command: sleep infinity

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,6 @@ services:
       - '3000:3000'
     volumes:
       - '.:/usr/src/app'
-    env_file:
-      - '.env'
     environment:
       VIRTUAL_HOST: .originality.docker
       DATABASE_URL: postgres://postgres:postgres@postgres/sdrt?

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - '5432:5432'
     volumes:
       - postgres:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: postgres
 
   redis:
     image: 'redis:3.2-alpine'
@@ -26,7 +28,7 @@ services:
       - '.env'
     environment:
       VIRTUAL_HOST: .originality.docker
-      DATABASE_URL: postgres://postgres@postgres/sdrt?
+      DATABASE_URL: postgres://postgres:postgres@postgres/sdrt?
 
 volumes:
   redis:

--- a/script/wait-for-it/LICENSE
+++ b/script/wait-for-it/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+Copyright (c) 2016 Giles Hall
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/script/wait-for-it/wait-for-it.sh
+++ b/script/wait-for-it/wait-for-it.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# Taken from https://github.com/vishnubob/wait-for-it. See the associated 
+# license in this directory, or visit the repo directory for more details.
+# Use this script to test if a given TCP host/port are available
+
+WAITFORIT_cmdname=${0##*/}
+
+echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $WAITFORIT_cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    else
+        echoerr "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
+    fi
+    WAITFORIT_start_ts=$(date +%s)
+    while :
+    do
+        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+            nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+            WAITFORIT_result=$?
+        else
+            (echo -n > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            WAITFORIT_result=$?
+        fi
+        if [[ $WAITFORIT_result -eq 0 ]]; then
+            WAITFORIT_end_ts=$(date +%s)
+            echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $WAITFORIT_result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $WAITFORIT_QUIET -eq 1 ]]; then
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    else
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    fi
+    WAITFORIT_PID=$!
+    trap "kill -INT -$WAITFORIT_PID" INT
+    wait $WAITFORIT_PID
+    WAITFORIT_RESULT=$?
+    if [[ $WAITFORIT_RESULT -ne 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    fi
+    return $WAITFORIT_RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        WAITFORIT_hostport=(${1//:/ })
+        WAITFORIT_HOST=${WAITFORIT_hostport[0]}
+        WAITFORIT_PORT=${WAITFORIT_hostport[1]}
+        shift 1
+        ;;
+        --child)
+        WAITFORIT_CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        WAITFORIT_QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        WAITFORIT_STRICT=1
+        shift 1
+        ;;
+        -h)
+        WAITFORIT_HOST="$2"
+        if [[ $WAITFORIT_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        WAITFORIT_HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        WAITFORIT_PORT="$2"
+        if [[ $WAITFORIT_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        WAITFORIT_PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        WAITFORIT_TIMEOUT="$2"
+        if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        WAITFORIT_TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        WAITFORIT_CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
+
+# Check to see if timeout is from busybox?
+WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
+WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
+
+WAITFORIT_BUSYTIMEFLAG=""
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+    WAITFORIT_ISBUSY=1
+    # Check if busybox timeout uses -t flag
+    # (recent Alpine versions don't support -t anymore)
+    if timeout &>/dev/stdout | grep -q -e '-t '; then
+        WAITFORIT_BUSYTIMEFLAG="-t"
+    fi
+else
+    WAITFORIT_ISBUSY=0
+fi
+
+if [[ $WAITFORIT_CHILD -gt 0 ]]; then
+    wait_for
+    WAITFORIT_RESULT=$?
+    exit $WAITFORIT_RESULT
+else
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        WAITFORIT_RESULT=$?
+    else
+        wait_for
+        WAITFORIT_RESULT=$?
+    fi
+fi
+
+if [[ $WAITFORIT_CLI != "" ]]; then
+    if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+        echoerr "$WAITFORIT_cmdname: strict mode, refusing to execute subprocess"
+        exit $WAITFORIT_RESULT
+    fi
+    exec "${WAITFORIT_CLI[@]}"
+else
+    exit $WAITFORIT_RESULT
+fi


### PR DESCRIPTION
After a great deal of headache and waiting, it looks like Travis is fixed and set up to use Docker for testing from now on. In an ideal world this tool would get way more love, like actually getting updated to a not EOLed version of Ruby, but the tool works for now, and it's not meant for production use anyways, so whatever.