### PR TITLE
Proxy fetching changes

### DIFF
--- a/app/controllers/tool_proxy_controller.rb
+++ b/app/controllers/tool_proxy_controller.rb
@@ -1,0 +1,28 @@
+class ToolProxyController < ApplicationController
+  include OriginalityReportsHelper
+  # obtain_guid_by_id
+  #
+  # Returns the guid of the tool proxy identified by the specified
+  # id.
+  #
+  # proxy_id - The id of the proxy to be found.
+  def obtain_guid_by_id
+    tp = ToolProxy.find(params[:proxy_id])
+  rescue ActiveRecord::RecordNotFound
+    head :not_found and return
+  else
+    render json: tp.guid, status: :ok
+  end
+
+  # obtain_guid_by_assignment_id
+  #
+  # Returns the guid of the first tool proxy associated with the given
+  # assignment.
+  #
+  #
+  def obtain_guid_by_assignment_tc_id
+    tp = tool_proxy_from_assignment
+    head :not_found and return unless tp.present?
+    render json: tp.guid, status: :ok
+  end
+end

--- a/app/controllers/tool_proxy_controller.rb
+++ b/app/controllers/tool_proxy_controller.rb
@@ -6,11 +6,9 @@ class ToolProxyController < ApplicationController
   # id.
   #
   # proxy_id - The id of the proxy to be found.
-  def obtain_guid_by_id
-    tp = ToolProxy.find(params[:proxy_id])
-  rescue ActiveRecord::RecordNotFound
-    head :not_found and return
-  else
+  def show_guid_by_id
+    tp = ToolProxy.where(id: params[:proxy_id]).first
+    head :not_found and return unless tp.present?
     render json: tp.guid, status: :ok
   end
 
@@ -20,7 +18,7 @@ class ToolProxyController < ApplicationController
   # assignment.
   #
   #
-  def obtain_guid_by_assignment_tc_id
+  def show_guid_by_assignment_tc_id
     tp = tool_proxy_from_assignment
     head :not_found and return unless tp.present?
     render json: tp.guid, status: :ok

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,11 @@ Rails.application.routes.draw do
     post 'assignments/:lti_assignment_id/update', action: :update, as: :assignment_update
   end
 
+  scope(controller: :tool_proxy) do
+    get 'tool_proxy/obtain_guid/:proxy_id', action: :obtain_guid_by_id
+    get 'tool_proxy/obtain_guid/assignment/:assignment_tc_id', action: :obtain_guid_by_assignment_tc_id
+  end
+
   scope(controller: :submissions) do
     get 'tool_proxy/:tool_proxy_guid/submissions/:tc_submission_id/retrieve',
         action: :retrieve_and_store, as: :submission_retrival

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,8 +11,8 @@ Rails.application.routes.draw do
   end
 
   scope(controller: :tool_proxy) do
-    get 'tool_proxy/obtain_guid/:proxy_id', action: :obtain_guid_by_id
-    get 'tool_proxy/obtain_guid/assignment/:assignment_tc_id', action: :obtain_guid_by_assignment_tc_id
+    get 'tool_proxy/obtain_guid/:proxy_id', action: :show_guid_by_id
+    get 'tool_proxy/obtain_guid/assignment/:assignment_tc_id', action: :show_guid_by_assignment_tc_id
   end
 
   scope(controller: :submissions) do

--- a/spec/controllers/tool_proxy_controller_spec.rb
+++ b/spec/controllers/tool_proxy_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe ToolProxyController, type: :controller do
-
   let(:shared_secret) { 'e5bf61debb355e4552732a943c74801ee02bc24ef1d6a077c6e68363fb9dcc4dceab75e6ae4f1e6ae9df5a6892ebbabe49feecc67f00f7e447b43f270e115c590533cd9a176a23eaba334834180da227521884bb49fae1993ca15d52c077b7d37d2ab6fd924a86a285f438f2fc161f63806468d1b977ff120635aa70f9d1d7a5' }
   let(:tool_proxy) { ToolProxy.create!(shared_secret: shared_secret, guid: SecureRandom.uuid, tcp_url: 'test.com', base_url: 'base.com') }
   let(:lti_assignment_id) { SecureRandom.uuid }

--- a/spec/controllers/tool_proxy_controller_spec.rb
+++ b/spec/controllers/tool_proxy_controller_spec.rb
@@ -6,27 +6,28 @@ RSpec.describe ToolProxyController, type: :controller do
   let(:lti_assignment_id) { SecureRandom.uuid }
   let(:assignment) { tool_proxy.assignments.create!(lti_assignment_id: lti_assignment_id, tc_id: SecureRandom.random_number) }
 
-  describe 'GET #obtain_guid_by_id' do
+  describe 'GET #show_guid_by_id' do
     it 'returns the guid for a valid proxy id' do
-      get :obtain_guid_by_id, params: { proxy_id: tool_proxy.id }
+      get :show_guid_by_id, params: { proxy_id: tool_proxy.id }
       expect(response).to have_http_status(:ok)
       expect(response.body).to eq(tool_proxy.guid)
     end
 
     it 'returns a 404 for an invalid proxy id' do
-      get :obtain_guid_by_id, params: { proxy_id: 55_041 }
+      get :show_guid_by_id, params: { proxy_id: 55_041 }
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe 'GET #obtain_guid_by_assignment_tc_id' do
+  describe 'GET #show_guid_by_assignment_tc_id' do
     it 'returns the correct proxy guid for a valid assignment tool consumer id' do
-      get :obtain_guid_by_assignment_tc_id, params: { assignment_tc_id: assignment.tc_id }
+      get :show_guid_by_assignment_tc_id, params: { assignment_tc_id: assignment.tc_id }
       expect(response.body).to eq(tool_proxy.guid)
     end
 
     it 'returns a 404 for an invalid assignment tool consumer id' do
-      get :obtain_guid_by_assignment_tc_id, params: { assignment_tc_id: 5_050_457 }
+      get :show_guid_by_assignment_tc_id, params: { assignment_tc_id: assignment.tc_id + 1 }
+      expect(response).to have_http_status(:not_found)
     end
   end
 end

--- a/spec/controllers/tool_proxy_controller_spec.rb
+++ b/spec/controllers/tool_proxy_controller_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe ToolProxyController, type: :controller do
+
+  let(:shared_secret) { 'e5bf61debb355e4552732a943c74801ee02bc24ef1d6a077c6e68363fb9dcc4dceab75e6ae4f1e6ae9df5a6892ebbabe49feecc67f00f7e447b43f270e115c590533cd9a176a23eaba334834180da227521884bb49fae1993ca15d52c077b7d37d2ab6fd924a86a285f438f2fc161f63806468d1b977ff120635aa70f9d1d7a5' }
+  let(:tool_proxy) { ToolProxy.create!(shared_secret: shared_secret, guid: SecureRandom.uuid, tcp_url: 'test.com', base_url: 'base.com') }
+  let(:lti_assignment_id) { SecureRandom.uuid }
+  let(:assignment) { tool_proxy.assignments.create!(lti_assignment_id: lti_assignment_id, tc_id: SecureRandom.random_number) }
+
+  describe 'GET #obtain_guid_by_id' do
+    it 'returns the guid for a valid proxy id' do
+      get :obtain_guid_by_id, params: { proxy_id: tool_proxy.id }
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to eq(tool_proxy.guid)
+    end
+
+    it 'returns a 404 for an invalid proxy id' do
+      get :obtain_guid_by_id, params: { proxy_id: 55_041 }
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'GET #obtain_guid_by_assignment_tc_id' do
+    it 'returns the correct proxy guid for a valid assignment tool consumer id' do
+      get :obtain_guid_by_assignment_tc_id, params: { assignment_tc_id: assignment.tc_id }
+      expect(response.body).to eq(tool_proxy.guid)
+    end
+
+    it 'returns a 404 for an invalid assignment tool consumer id' do
+      get :obtain_guid_by_assignment_tc_id, params: { assignment_tc_id: 5_050_457 }
+    end
+  end
+end


### PR DESCRIPTION
These commits allow us to obtain the necessary information to use this tool for integration testing with Canvas. Mainly, they allow us to fetch the guid of a tool proxy by either its id, or by the assignment tool consumer id (ie the assignment's id in Canvas). One odd thing to note is that the assignment_tc_id is NOT globalized, so this tool would struggle to work with multi-sharded versions of Canvas. That's a separate issue though.